### PR TITLE
Fix: Change to non-null on send-tx Orchestrate

### DIFF
--- a/files/orchestrate/src/send-tx/send-tx.ts
+++ b/files/orchestrate/src/send-tx/send-tx.ts
@@ -12,7 +12,7 @@ export const sendTx = async () => {
       params: {
         methodSignature: 'increment(uint256)',
         args: [1],
-        to: process.env.TO_ACCOUNT,
+        to: process.env.TO_ACCOUNT!,
         from: process.env.FROM_ACCOUNT!
       }
     },


### PR DESCRIPTION
Hi, I found the error on typescript when I try to run `npm run send-tx` using orchestrate setting.

I think that the type declaration will accept a string for attribute `to`, when I send a transaction. The `to` should not be undefined value because `to` is required for complete transaction sending.

```bash
> codefi-orchestrate-quick-start@2.3.0 send-tx /Users/user/Works/path/to/quorum-test-network
> dotenv ts-node src/send-tx


/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:434
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
src/send-tx/send-tx.ts:15:9 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

15         to: process.env.TO_ACCOUNT,
           ~~

  node_modules/pegasys-orchestrate/lib/http/types/ITransaction.d.ts:13:5
    13     to: string;
           ~~
    The expected type comes from property 'to' which is declared here on type 'ITransactionParams'

    at createTSError (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:434:12)
    at reportTSError (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:438:19)
    at getOutput (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:578:36)
    at Object.compile (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:775:32)
    at Module.m._compile (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:858:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:1158:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/user/Works/path/to/quorum-test-network/node_modules/ts-node/src/index.ts:861:12)
    at Module.load (internal/modules/cjs/loader.js:986:32)
    at Function.Module._load (internal/modules/cjs/loader.js:879:14)
    at Module.require (internal/modules/cjs/loader.js:1026:19)
```

**Environment:** NodeJS v12.18.2 