### PR TITLE
Add chainid to signed transactions

### DIFF
--- a/files/goquorum/smart_contracts/scripts/private_tx.js
+++ b/files/goquorum/smart_contracts/scripts/private_tx.js
@@ -34,6 +34,7 @@ async function createContract(client, fromPrivateKey, fromPublicKey, toPublicKey
   const txCount = await web3.eth.getTransactionCount(`0x${accountAddress}`);
 
   const txOptions = {
+    chainId,
     nonce: txCount,
     gasPrice: 0, //ETH per unit of gas
     gasLimit: 0x24A22, //max number of gas units the tx is allowed to use

--- a/files/goquorum/smart_contracts/scripts/private_tx_web3.js
+++ b/files/goquorum/smart_contracts/scripts/private_tx_web3.js
@@ -15,6 +15,7 @@ const contractAbi = contractJson.abi;
 async function getValueAtAddress(host, nodeName="node", deployedContractAbi, deployedContractAddress){
   const web3 = new Web3(host);
   const contractInstance = new web3.eth.Contract(deployedContractAbi, deployedContractAddress);
+  contractInstance.defaultCommon.customChain = {name: 'GoQuorum', chainId: 1337};
   const res = await contractInstance.methods.get().call().catch(() => {});
   console.log(nodeName + " obtained value at deployed contract is: "+ res);
   return res

--- a/files/goquorum/smart_contracts/scripts/public_tx.js
+++ b/files/goquorum/smart_contracts/scripts/public_tx.js
@@ -45,6 +45,7 @@ async function createContract(host) {
   console.log(account);
 
   const rawTxOptions = {
+    chainId: 1337,
     nonce: "0x00",
     from: account.address,
     to: null, //public tx

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-dev-quickstart",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quorum-dev-quickstart",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "A utility that lets developers try out the new suite of Quorum tools from ConsenSys!",
   "main": "build/index.js",
   "repository": "git@github.com:ConsenSys/quorum-dev-quickstart.git",

--- a/templates/goquorum/docker-compose.yml
+++ b/templates/goquorum/docker-compose.yml
@@ -112,6 +112,7 @@ x-quorum-def:
       geth --datadir=/data init /config/genesis.json;
       cp /config/keys/accountkey /data/keystore/key;
       cp /config/keys/nodekey /data/geth/nodekey;
+      export ADDRESS=$$(grep -o '"address": *"[^"]*"' /config/keys/accountkey | grep -o '"[^"]*"$$' | sed 's/"//g')
       geth \
       --datadir /data \
       --nodiscover \
@@ -125,7 +126,7 @@ x-quorum-def:
       --ws --ws.addr 0.0.0.0 --ws.port 8546 --ws.origins "*" --ws.api admin,db,eth,debug,miner,net,shh,txpool,personal,web3,quorum,$$QUORUM_API \
       --port 30303 \
       --identity node$${NODE_ID}-$${GOQUORUM_CONS_ALGO} \
-      --unlock 0 \
+      --unlock $${ADDRESS} \
       --allow-insecure-unlock \
       --password /config/passwords.txt \
       &> /var/log/quorum/geth-$$HOSTNAME-$$(hostname -i).log | tee -a /var/log/quorum/geth-$$HOSTNAME-$$(hostname -i).log
@@ -186,6 +187,7 @@ x-quorum-member-def:
       geth --datadir=/data/dd init /config/genesis.json;
       cp /config/keys/accountkey /data/dd/keystore/key;
       cp /config/keys/nodekey /data/dd/geth/nodekey;
+      export ADDRESS=$$(grep -o '"address": *"[^"]*"' /config/keys/accountkey | grep -o '"[^"]*"$$' | sed 's/"//g')
       geth \
       --datadir /data/dd \
       --nodiscover \
@@ -200,7 +202,7 @@ x-quorum-member-def:
       --port 30303 \
       --identity node$${NODE_ID}-$${GOQUORUM_CONS_ALGO} \
       --ptm.timeout 5 --ptm.url $${QUORUM_PTM_URL} --ptm.http.writebuffersize 4096 --ptm.http.readbuffersize 4096 --ptm.tls.mode off \
-      --unlock 0 \
+      --unlock $${ADDRESS} \
       --allow-insecure-unlock \
       --password /config/passwords.txt \
       &> /var/log/quorum/geth-$$(hostname -i).log | tee -a /var/log/quorum/geth-$$(hostname -i).log


### PR DESCRIPTION
As part of the changes to signing raw transactions geth now requires chainID to be specified when signing transactions. This can be mitigated with `--rpc.allow-unprotected-txs` or just providing the chainId! 

https://blog.ethereum.org/2021/03/03/geth-v1-10-0/