### PR TITLE
Fixing Tessera file logging configuration

### DIFF
--- a/files/common/config/tessera/data/logback.xml
+++ b/files/common/config/tessera/data/logback.xml
@@ -10,7 +10,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-      <file>"/var/log/tessera/tessera-${env:HOSTNAME}.log"</file>
+      <file>/var/log/tessera/tessera-$HOSTNAME.log</file>
       <append>true</append>
       <immediateFlush>true</immediateFlush>
       <encoder>

--- a/files/common/config/tessera/docker-entrypoint.sh
+++ b/files/common/config/tessera/docker-entrypoint.sh
@@ -7,9 +7,6 @@ envsubst < /data/tessera-config-template.json > /data/tessera-config.json
 
 cat /data/tessera-config.json
 
-touch /var/log/tessera/tessera-$(hostname -i).log
-chmod 777 /var/log/tessera/tessera-$(hostname -i).log
-
 exec /tessera/bin/tessera \
     -configfile /data/tessera-config.json
 


### PR DESCRIPTION
Quotes in the previous configuration were not interpreted correctly and environment variable was not injected.