### PR TITLE
Update blockscout image version to support private transactions

### DIFF
--- a/templates/besu/docker-compose.yml
+++ b/templates/besu/docker-compose.yml
@@ -211,7 +211,7 @@ x-docker-logging:
 
 x-blockscout-ref:
   &blockscout-def
-  image: consensys/blockscout:v4.0.0-beta
+  image: consensys/blockscout:v4.1.3-beta
   container_name: blockscout
   restart: "no"
   environment:

--- a/templates/besu/docker-compose.yml
+++ b/templates/besu/docker-compose.yml
@@ -216,7 +216,7 @@ x-blockscout-ref:
   restart: "no"
   environment:
     - PORT=4000
-    - DATABASE_URL=ecto://postgres:postgres@blockscoutpostgres/postgres?ssl=false
+    - DATABASE_URL=ecto://postgres:postgres@blockscoutpostgres:5432/postgres?ssl=false
     - POSTGRES_PASSWORD=postgres
     - POSTGRES_USER=postgres
     - NETWORK=quickstart

--- a/templates/goquorum/docker-compose.yml
+++ b/templates/goquorum/docker-compose.yml
@@ -118,7 +118,7 @@ x-tessera-def:
 
 x-blockscout-ref:
   &blockscout-def
-  image: consensys/blockscout:v4.0.0-beta
+  image: consensys/blockscout:v4.1.3-beta
   container_name: blockscout
   restart: "no"
   environment:

--- a/templates/goquorum/docker-compose.yml
+++ b/templates/goquorum/docker-compose.yml
@@ -123,7 +123,7 @@ x-blockscout-ref:
   restart: "no"
   environment:
     - PORT=4000
-    - DATABASE_URL=ecto://postgres:postgres@blockscoutpostgres/postgres?ssl=false
+    - DATABASE_URL=ecto://postgres:postgres@blockscoutpostgres:5432/postgres?ssl=false
     - POSTGRES_PASSWORD=postgres
     - POSTGRES_USER=postgres
     - NETWORK=quickstart


### PR DESCRIPTION
Current blockscout version v4.0.0 doesn't support private transaction, a fix was added on v4.1.3. The docker image for consensys/blockscout was updated accordingly, but the provided `DATABASE_URL`, without the port, fails to initialize.