### PR TITLE
Updating logging configuration file

### DIFF
--- a/files/besu/config/besu/log-config.xml
+++ b/files/besu/config/besu/log-config.xml
@@ -9,11 +9,12 @@
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout alwaysWriteExceptions="false" pattern='{"timestamp":"%d{ISO8601}","container":"${hostName}","level":"%level","thread":"%t","class":"%c{1}","message":"%msg","throwable":"%enc{%throwable}{JSON}"}%n'/>
     </Console>
-    <RollingFile name="RollingFile" fileName="/tmp/besu/besu-${env:HOSTNAME}.log" filePattern="/tmp/besu/besu-${env:HOSTNAME}.log" >
+    <RollingFile name="RollingFile" fileName="/tmp/besu/besu-${env:HOSTNAME}.log" filePattern="/tmp/besu/besu-${env:HOSTNAME}_%d{yyyy-MM-dd}_%i.log.gz" >
       <PatternLayout alwaysWriteExceptions="false" pattern='{"timestamp":"%d{ISO8601}","container":"${hostName}","level":"%level","thread":"%t","class":"%c{1}","message":"%msg","throwable":"%enc{%throwable}{JSON}"}%n'/>
       <Policies>
         <SizeBasedTriggeringPolicy size="10 MB" />
       </Policies>
+      <DefaultRolloverStrategy max="5" />
     </RollingFile>
   </Appenders>
 


### PR DESCRIPTION
Changing configuration to effectively roll Besu's log file

Current configuration did not roll log file at 10 MBs. Making "filePattern" different from "fileName" fixes this behaviour.

The proposed configuration zips log files (fixing filePattern) and keeps the last 5 archived files.