### PR TITLE
modify docker compose network parameter

### DIFF
--- a/templates/orchestrate/docker-compose.qkm.yml
+++ b/templates/orchestrate/docker-compose.qkm.yml
@@ -57,5 +57,5 @@ networks:
     name: qkm_quorum-dev-quickstart
     driver: bridge
   deps:
-    external:
-      name: deps_quorum-dev-quickstart
+    name: deps_quorum-dev-quickstart
+    external: true

--- a/templates/orchestrate/docker-compose.yml
+++ b/templates/orchestrate/docker-compose.yml
@@ -129,11 +129,11 @@ networks:
   orchestrate:
     name: orchestrate_quorum-dev-quickstart
   deps:
-    external:
-      name: deps_quorum-dev-quickstart
+    name: deps_quorum-dev-quickstart
+    external: true
   qkm:
-    external:
-      name: qkm_quorum-dev-quickstart
+    name: qkm_quorum-dev-quickstart
+    external: true
   network:
-    external:
-      name: quorum-dev-quickstart
+    name: quorum-dev-quickstart
+    external: true

--- a/templates/quorum-key-manager/docker-compose.yml
+++ b/templates/quorum-key-manager/docker-compose.yml
@@ -56,5 +56,5 @@ networks:
   qkm:
     name: qkm_quorum-dev-quickstart
   deps:
-    external:
-      name: deps_quorum-dev-quickstart
+    name: deps_quorum-dev-quickstart
+    external: true


### PR DESCRIPTION
Since `network.external.name` is obsolete, the parameter is changed to
```
WARN[0000] network deps: network.external.name is deprecated. Please set network.name with external: true
```