### PR TITLE
Set zeroBaseFee true

### DIFF
--- a/files/besu/config/besu/CLIQUEgenesis.json
+++ b/files/besu/config/besu/CLIQUEgenesis.json
@@ -2,6 +2,7 @@
   "config":{
     "chainId":1337,
     "londonBlock": 0,
+    "zeroBaseFee": true,
     "clique":{
       "blockperiodseconds":15,
       "epochlength":30000

--- a/files/besu/config/besu/IBFTgenesis.json
+++ b/files/besu/config/besu/IBFTgenesis.json
@@ -14,6 +14,7 @@
     "londonBlock": 0,
     "arrowGlacierBlock": 0,
     "grayGlacierBlock": 0,
+    "zeroBaseFee": true,
     "ibft2" : {
       "blockperiodseconds" : 5,
       "epochlength" : 30000,

--- a/files/besu/config/besu/QBFTgenesis.json
+++ b/files/besu/config/besu/QBFTgenesis.json
@@ -14,6 +14,7 @@
       "londonBlock": 0,
       "arrowGlacierBlock": 0,
       "grayGlacierBlock": 0,
+      "zeroBaseFee": true,
       "qbft": {
         "epochlength": 30000,
         "blockperiodseconds": 5,


### PR DESCRIPTION
When https://github.com/Consensys/quorum-dev-quickstart/commit/06d1a8241eb2069b2ece7a391e9fc7046a780dac updated the genesis files to add the `londonBlock` it missed off the need to set `zeroBaseFee: true` for free gas chains.