### PR TITLE
Fix for tessera not working in mac m1/m2

### DIFF
--- a/files/common/config/tessera/Dockerfile
+++ b/files/common/config/tessera/Dockerfile
@@ -1,6 +1,6 @@
 ARG TESSERA_VERSION=latest
 
-FROM quorumengineering/tessera:${TESSERA_VERSION}
+FROM --platform=amd64 quorumengineering/tessera:${TESSERA_VERSION}
 
 # develop uses a debain container, all releases use an alpine container - this allows both to be used for the quickstart
 # set the version in ../../.env


### PR DESCRIPTION
Fix for https://github.com/Consensys/quorum-dev-quickstart/issues/277

This is hack or hot fix for mac m1/m2 machines, if we pull tessera amd64 arch docker it works fine in mac m1/m2 machines too.