### PR TITLE
change docker-compose.yml to take multiple merge keys as array 

### DIFF
--- a/templates/besu/docker-compose.yml
+++ b/templates/besu/docker-compose.yml
@@ -747,15 +747,13 @@ services:
         ipv4_address: 172.16.239.42
 
   otelcollector:
-    << : *otelcollector-def
-    << : *docker-logging
+    << : [*otelcollector-def, *docker-logging]
     networks:
       quorum-dev-quickstart:
         ipv4_address: 172.16.239.43
 
   ethlogger:
-    << : *ethlogger-def
-    << : *docker-logging
+    << : [*ethlogger-def, *docker-logging]
     networks:
       quorum-dev-quickstart:
         ipv4_address: 172.16.239.44


### PR DESCRIPTION
A change was made in version 2.17 to improve YAML parsing, specifically allowing multiple merge keys to be treated as an array. You can check the details in this GitHub issue: https://github.com/docker/compose/issues/10411.