### PR TITLE
fix: Add Redis dependency to resolve missing service error

### DIFF
--- a/templates/besu/docker-compose.yml
+++ b/templates/besu/docker-compose.yml
@@ -276,7 +276,10 @@ x-chainlensapi-ref:
     - REINDEX_ENDPOINT=http://chainlensingestion/reindex/
     - MONGO_DB_NAME=epirus
     - MONGO_CREATE_INDICES=true
+    - REDIS_HOST=chainlensredis
+    - REDIS_PORT=6379
   depends_on:
+    - chainlensredis
     - chainlensmongodb
 
 x-chainlensmongodb-ref:
@@ -288,12 +291,18 @@ x-chainlensmongodb-ref:
     - DOCKER_CLIENT_TIMEOUT=900
   entrypoint: mongod --bind_ip "0.0.0.0"
 
+x-chainlensredis-ref:
+  &chainlensredis-def
+  image: redis
+  container_name: chainlensredis
+
 x-chainlensweb-ref:
   &chainlensweb-def
   image: web3labs/epirus-free-web:latest
   container_name: chainlensweb
   environment:
     - API_URL=/api
+    - WS_API_URL=ws://localhost:8090
     - DISPLAY_NETWORK_TAB=disabled
   depends_on:
     - chainlensapi
@@ -647,6 +656,12 @@ services:
     networks:
       quorum-dev-quickstart:
         ipv4_address: 172.16.239.57
+
+  chainlensredis:
+    <<: *chainlensredis-def
+    networks:
+      quorum-dev-quickstart:
+        ipv4_address: 172.16.239.58
 
 {% endif %}
 


### PR DESCRIPTION
## Overview

This pull request addresses the issue of missing Redis dependency in the `docker-compose.yml` file, which was causing errors. The following changes have been made:

1. **Redis Service Addition:**
   - Added a new service definition for Redis under `x-chainlensredis-ref`.
   - Defined the Redis container using the `redis` image with the container name `chainlensredis`.

2. **Chainlens API Updates:**
   - Included environment variables `REDIS_HOST` and `REDIS_PORT` in `x-chainlensapi-ref` for Redis connectivity.
   - Updated the `depends_on` section in `x-chainlensapi-ref` to include `chainlensredis`.

3. **Chainlens Web Updates:**
   - Added `WS_API_URL` environment variable in `x-chainlensweb-ref`.

4. **Service Configuration:**
   - Added `chainlensredis` service to the main `services` section with an assigned IP address in the `quorum-dev-quickstart` network.

## Motivation

This fix ensures that the Chainlens API functions correctly by resolving the error caused by the missing Redis service.

## Testing

- Verified that the `docker-compose` setup runs successfully with the new Redis service.
- Ensured that the Chainlens API can connect to Redis and operate without errors.
