### PR TITLE
declare fullAccess as constant to reduce gas and improve clarity (issue: #294)

### DIFF
--- a/files/goquorum/smart_contracts/permissioning/contracts/v2/PermissionsImplementation.sol
+++ b/files/goquorum/smart_contracts/permissioning/contracts/v2/PermissionsImplementation.sol
@@ -25,7 +25,7 @@ contract PermissionsImplementation {
     string private orgAdminRole;
 
 
-    uint256 private fullAccess = 3;
+    uint256 private constant fullAccess = 3;
 
     /** @dev this variable is meant for tracking the initial network boot up
         once the network boot up is done the value is set to true


### PR DESCRIPTION
Code changes have been made for the reported [issue](https://github.com/Consensys/quorum-dev-quickstart/issues/294).


**Changes:**
```solidity
// Before
uint256 private fullAccess = 3;

// After  
uint256 private constant fullAccess = 3;
```

**Impact of changes:**
- Gas optimization: Saves 97 gas per variable access (SLOAD → PUSH operation)
- Storage efficiency: Eliminates unnecessary storage slot, reducing deployment costs
- Code stability: Prevents accidental value modification through constant declaration

Hope this helps.